### PR TITLE
hailo-pci: use proper GPLv2 license file

### DIFF
--- a/meta-hailo-accelerator/recipes-firmware/hailo-firmware/hailo-firmware-eth_4.15.0.bb
+++ b/meta-hailo-accelerator/recipes-firmware/hailo-firmware/hailo-firmware-eth_4.15.0.bb
@@ -2,15 +2,15 @@ DESCRIPTION = "hailo firmware eth \
 			   hailo8 chip firmware for using the ethernet interface (hailo_fw.bin) \
 			   the recipe copies the file to /lib/firmware/hailo/ on the target device’s root file system"
 
+LICENSE = "CLOSED"
+LICENSE_FILE = "LICENSE"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/${LICENSE_FILE};md5=263ee034adc02556d59ab1ebdaea2cda"
+
 BASE_URI = "https://hailo-hailort.s3.eu-west-2.amazonaws.com"
 FW_AWS_DIR = "Hailo8/${PV}/FW"
 FW = "hailo8_fw.${PV}_eth.bin"
-LICENSE_FILE = "LICENSE"
 SRC_URI = "${BASE_URI}/${FW_AWS_DIR}/${FW};md5sum=991b6d22231fe7457ba96b7b00cc22c8 \
 		${BASE_URI}/${FW_AWS_DIR}/${LICENSE_FILE};md5sum=263ee034adc02556d59ab1ebdaea2cda"
-
-LICENSE = "LICENSE"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/${LICENSE_FILE};md5=263ee034adc02556d59ab1ebdaea2cda"
 
 FW_PATH = "${WORKDIR}/${FW}"
 

--- a/meta-hailo-accelerator/recipes-firmware/hailo-firmware/hailo-firmware_4.15.0.bb
+++ b/meta-hailo-accelerator/recipes-firmware/hailo-firmware/hailo-firmware_4.15.0.bb
@@ -2,15 +2,15 @@ DESCRIPTION = "hailo firmware \
 				hailo8 chip firmware (hailo_fw.bin) \
 				the recipe copies the file to /lib/firmware/hailo/ on the target device’s root file system"
 
+LICENSE = "CLOSED"
+LICENSE_FILE = "LICENSE"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/${LICENSE_FILE};md5=263ee034adc02556d59ab1ebdaea2cda"
+
 BASE_URI = "https://hailo-hailort.s3.eu-west-2.amazonaws.com"
 FW_AWS_DIR = "Hailo8/${PV}/FW"
 FW = "hailo8_fw.${PV}.bin"
-LICENSE_FILE = "LICENSE"
 SRC_URI = "${BASE_URI}/${FW_AWS_DIR}/${FW};md5sum=2622de442a92149f60da846906490a8c \
 		${BASE_URI}/${FW_AWS_DIR}/${LICENSE_FILE};md5sum=263ee034adc02556d59ab1ebdaea2cda"
-
-LICENSE = "LICENSE"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/${LICENSE_FILE};md5=263ee034adc02556d59ab1ebdaea2cda"
 
 FW_PATH = "${WORKDIR}/hailo8_fw.${PV}.bin"
 

--- a/meta-hailo-accelerator/recipes-kernel/hailo-pci/hailo-pci_4.15.0.bb
+++ b/meta-hailo-accelerator/recipes-kernel/hailo-pci/hailo-pci_4.15.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "hailo pcie driver \
                the recipe calls the compilation process with the proper cross-compiler and kernel directory. \
                the output of the compilation (hailo_pci.ko) is copied to the target's rootfs"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://../../LICENSE;md5=39bba7d2cf0ba1036f2a6e2be52fe3f0"
 
 SRC_URI = "git://git@github.com/hailo-ai/hailort-drivers.git;protocol=https;branch=master"


### PR DESCRIPTION
Just some small fixes/cleanups to prevent Yocto warnings.